### PR TITLE
MOV-989 DaysOfWeek to Allow either 0 or 7

### DIFF
--- a/src/TemporalExpressions/TEDaysOfWeek.php
+++ b/src/TemporalExpressions/TEDaysOfWeek.php
@@ -243,7 +243,9 @@ class TEDaysOfWeek extends ACTemporalExpression
 
         return $instance >= $start
             && (is_null($end) || $instance <= $end)
-            && in_array((new Carbon($date))->dayOfWeek, $this->days)
+            && collect($this->days)->contains(function ($day) use ($instance) {
+                return $day % 7 === $instance->dayOfWeek;
+            })
             && $this->hasCorrectFrequencyFromStart($instance, $start)
             && !$this->isIgnored($instance);
     }

--- a/tests/TestCases/TemporalExpressions/TEDaysOfWeekTest.php
+++ b/tests/TestCases/TemporalExpressions/TEDaysOfWeekTest.php
@@ -377,4 +377,31 @@ class TEDaysOfWeekTest extends TestCase
         $next = $pattern->next();
         $this->assertEquals('2021-01-18', $next->format('Y-m-d'));
     }
+
+    // I'm trying to make sure Sunday is included in the pattern
+    // This one works
+    public function testDayResolvesIncludingSundayFrom0()
+    {
+        $pattern1 = TEDaysOfWeek::build(Carbon::create('2022-12-01'), [0])
+            ->setFrequency(1);
+        
+        $testDate1 = Carbon::create('2022-12-11');
+            
+        $result1 = $pattern1->includes($testDate1);
+        $this->assertTrue($result1);
+
+    }
+    
+    // This one fails
+    public function testDayResolvesIncludingSundayFrom7()
+    {
+        $pattern1 = TEDaysOfWeek::build(Carbon::create('2022-12-01'), [7])
+            ->setFrequency(1);
+        
+        $testDate1 = Carbon::create('2022-12-11');
+            
+        $result1 = $pattern1->includes($testDate1);
+        $this->assertTrue($result1);
+
+    }
 }

--- a/tests/TestCases/TemporalExpressions/TEDaysOfWeekTest.php
+++ b/tests/TestCases/TemporalExpressions/TEDaysOfWeekTest.php
@@ -378,30 +378,15 @@ class TEDaysOfWeekTest extends TestCase
         $this->assertEquals('2021-01-18', $next->format('Y-m-d'));
     }
 
-    // I'm trying to make sure Sunday is included in the pattern
-    // This one works
-    public function testDayResolvesIncludingSundayFrom0()
-    {
-        $pattern1 = TEDaysOfWeek::build(Carbon::create('2022-12-01'), [0])
-            ->setFrequency(1);
-        
-        $testDate1 = Carbon::create('2022-12-11');
-            
-        $result1 = $pattern1->includes($testDate1);
-        $this->assertTrue($result1);
-
-    }
-    
-    // This one fails
+    // Make sure Sunday is included in the pattern
     public function testDayResolvesIncludingSundayFrom7()
     {
-        $pattern1 = TEDaysOfWeek::build(Carbon::create('2022-12-01'), [7])
+        $pattern1 = TEDaysOfWeek::build(Carbon::create('2022-12-01'), [1, 2, 3, 4, 5, 6, 7])
             ->setFrequency(1);
         
         $testDate1 = Carbon::create('2022-12-11');
             
         $result1 = $pattern1->includes($testDate1);
         $this->assertTrue($result1);
-
     }
 }


### PR DESCRIPTION
The `includes` condition fails for Sunday because Carbon dayOfWeek returns zero for Sunday instead of 7.
```php
> (new Carbon("2022-12-11"))->dayOfWeek
= 0
```
The condition was rewritten to handle it (thanks for the assist @nickrupert7 ).